### PR TITLE
Fix: Remove TopMenu for isGuest

### DIFF
--- a/Events.php
+++ b/Events.php
@@ -32,6 +32,10 @@ class Events extends BaseObject
     public static function onTopMenuInit($event)
     {
 
+        if (Yii::$app->user->isGuest) {
+            return;
+        }
+
         // Is Module enabled on this workspace?
         $event->sender->addItem([
             'label' => Yii::t('BookmarkModule.base', 'Bookmarks'),


### PR DESCRIPTION
At the moment you'll get an error saying you can't do this action when clicking on the Bookmark tab, with this it removes the tab option for `isGuest` altogether.